### PR TITLE
feature/ipv6 support

### DIFF
--- a/guided_docker_compose.py
+++ b/guided_docker_compose.py
@@ -111,7 +111,7 @@ def configure_chn():
             domain = 'https://' + domain
         url_parsed = urlparse(domain)
         try:
-            socket.gethostbyname(url_parsed.netloc)
+            socket.getaddrinfo(url_parsed.netloc, 443)
         except Exception as e:
             sys.stderr.write(
                 make_color("FAIL",


### PR DESCRIPTION
gethostbyname doesn't support ipv6, so replace it with getaddrinfo. The new func also requires a port, but for our purposes it doesn't matter which one, so just added 443.